### PR TITLE
Avoid NPE in ScoverageProjectAction.doDynamic

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scoverage/ScoverageProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/scoverage/ScoverageProjectAction.java
@@ -57,11 +57,14 @@ public class ScoverageProjectAction implements Action {
 
     public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, InterruptedException {
         if (project.getLastBuild() != null && getDisplayName() != null) {
-            String url = getLastSuccessfulBuildAction().getUrlName();
-            FilePath path = new FilePath(project.getLastBuild().getRootDir()).child(url);
-            return new DirectoryBrowserSupport(this, path, "Scoverage HTML Report", "", false);
-        } else {
-            return null;
+	    ScoverageBuildAction lastSuccessfulAction = getLastSuccessfulBuildAction();
+	    if (lastSuccessfulAction != null) {
+		String url = lastSuccessfulAction.getUrlName();
+		FilePath path = new FilePath(project.getLastBuild().getRootDir()).child(url);
+
+		return new DirectoryBrowserSupport(this, path, "Scoverage HTML Report", "", false);
+	    }
         }
+	return null;
     }
 }


### PR DESCRIPTION
The exception was thrown when getLastSuccessfulBuildAction returned null.

Fixes JENKINS-27418
