### PR TITLE
[JENKINS-57244] Unnecessary and dangerous persistent fields in a RunAction

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scoverage/ScoverageBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/scoverage/ScoverageBuildAction.java
@@ -17,18 +17,28 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import jenkins.model.RunAction2;
 
 @ExportedBean
-public class ScoverageBuildAction implements Action, SimpleBuildStep.LastBuildAction {
+public class ScoverageBuildAction implements RunAction2, SimpleBuildStep.LastBuildAction {
 
-    private final Run<?, ?> run;
+    private transient Run<?, ?> run;
     private final FilePath buildPath;
     private final ScoverageResult result;
 
-    public ScoverageBuildAction(Run<?, ?> run, FilePath buildPath, ScoverageResult result) {
-        this.run = run;
+    public ScoverageBuildAction(FilePath buildPath, ScoverageResult result) {
         this.buildPath = buildPath;
         this.result = result;
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> r) {
+        run = r;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> r) {
+        run = r;
     }
 
     public String getIconFileName() {

--- a/src/main/java/org/jenkinsci/plugins/scoverage/ScoverageBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/scoverage/ScoverageBuildAction.java
@@ -7,7 +7,6 @@ import hudson.model.DirectoryBrowserSupport;
 import hudson.model.Result;
 import hudson.model.Run;
 import jenkins.tasks.SimpleBuildStep;
-import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -23,11 +22,9 @@ import jenkins.model.RunAction2;
 public class ScoverageBuildAction implements RunAction2, SimpleBuildStep.LastBuildAction {
 
     private transient Run<?, ?> run;
-    private final FilePath buildPath;
     private final ScoverageResult result;
 
-    public ScoverageBuildAction(FilePath buildPath, ScoverageResult result) {
-        this.buildPath = buildPath;
+    public ScoverageBuildAction(ScoverageResult result) {
         this.result = result;
     }
 
@@ -80,7 +77,7 @@ public class ScoverageBuildAction implements RunAction2, SimpleBuildStep.LastBui
     }
 
     public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, InterruptedException {
-        return new DirectoryBrowserSupport(this, buildPath.child(getUrlName()), "Scoverage HTML Report", "", false);
+        return new DirectoryBrowserSupport(this, new FilePath(run.getRootDir()).child(getUrlName()), "Scoverage HTML Report", "", false);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/scoverage/ScoveragePublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/scoverage/ScoveragePublisher.java
@@ -65,7 +65,7 @@ public class ScoveragePublisher extends Recorder implements SimpleBuildStep {
 
         copyReport(scovPath, buildPath, new BuildListenerAdapter(listener));
         ScoverageResult result = processReport(run, buildPath);
-        run.addAction(new ScoverageBuildAction(run, buildPath, result));
+        run.addAction(new ScoverageBuildAction(buildPath, result));
     }
 
     private static final class ScovFinder implements FilePath.FileCallable<File> {

--- a/src/main/java/org/jenkinsci/plugins/scoverage/ScoveragePublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/scoverage/ScoveragePublisher.java
@@ -65,7 +65,7 @@ public class ScoveragePublisher extends Recorder implements SimpleBuildStep {
 
         copyReport(scovPath, buildPath, new BuildListenerAdapter(listener));
         ScoverageResult result = processReport(run, buildPath);
-        run.addAction(new ScoverageBuildAction(buildPath, result));
+        run.addAction(new ScoverageBuildAction(result));
     }
 
     private static final class ScovFinder implements FilePath.FileCallable<File> {

--- a/src/test/java/org/jenkinsci/plugins/scoverage/ScoverageBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scoverage/ScoverageBuildActionTest.java
@@ -1,8 +1,6 @@
 package org.jenkinsci.plugins.scoverage;
 
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
-import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -10,10 +8,9 @@ import java.io.File;
 import static org.testng.Assert.assertEquals;
 
 public class ScoverageBuildActionTest {
-    private AbstractBuild build = Mockito.mock(AbstractBuild.class);
     private FilePath path = new FilePath(new File("foo/bar"));
     private ScoverageResult result = new ScoverageResult(95.27, 50.0, 1);
-    private ScoverageBuildAction action = new ScoverageBuildAction(build, path, result);
+    private ScoverageBuildAction action = new ScoverageBuildAction(path, result);
 
     @Test
     public void urlTest() {

--- a/src/test/java/org/jenkinsci/plugins/scoverage/ScoverageBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scoverage/ScoverageBuildActionTest.java
@@ -1,16 +1,12 @@
 package org.jenkinsci.plugins.scoverage;
 
-import hudson.FilePath;
 import org.testng.annotations.Test;
-
-import java.io.File;
 
 import static org.testng.Assert.assertEquals;
 
 public class ScoverageBuildActionTest {
-    private FilePath path = new FilePath(new File("foo/bar"));
     private ScoverageResult result = new ScoverageResult(95.27, 50.0, 1);
-    private ScoverageBuildAction action = new ScoverageBuildAction(path, result);
+    private ScoverageBuildAction action = new ScoverageBuildAction(result);
 
     @Test
     public void urlTest() {


### PR DESCRIPTION
See [JENKINS-57244](https://issues.jenkins-ci.org/browse/JENKINS-57244). Untested, as this plugin lacks any meaningful (i.e., non-mock) test cases.

See https://github.com/jenkinsci/jenkins/pull/4011 for the amelioration.